### PR TITLE
Fetch NumberEntity data only when enabled.

### DIFF
--- a/custom_components/ezviz_cloud/number.py
+++ b/custom_components/ezviz_cloud/number.py
@@ -66,14 +66,11 @@ async def async_setup_entry(
     ]
 
     async_add_entities(
-        [
-            EzvizSensor(coordinator, camera, value, entry.entry_id)
-            for camera in coordinator.data
-            for capibility, value in coordinator.data[camera]["supportExt"].items()
-            if capibility == NUMBER_TYPE.supported_ext
-            if value in NUMBER_TYPE.supported_ext_value
-        ],
-        update_before_add=True,
+        EzvizSensor(coordinator, camera, value, entry.entry_id)
+        for camera in coordinator.data
+        for capibility, value in coordinator.data[camera]["supportExt"].items()
+        if capibility == NUMBER_TYPE.supported_ext
+        if value in NUMBER_TYPE.supported_ext_value
     )
 
 
@@ -97,6 +94,10 @@ class EzvizSensor(EzvizBaseEntity, NumberEntity):
         self.entity_description = NUMBER_TYPE
         self.config_entry_id = config_entry_id
         self.sensor_value: int | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Run when about to be added to hass."""
+        await self.hass.async_add_executor_job(self.update)
 
     @property
     def native_value(self) -> float | None:


### PR DESCRIPTION
Force update on async_add_entities always calls Update, even when disabled.

Moved update to async_added_to_hass to prevent this. Now it fetches data only when the entity is enabled.