### PR TITLE
Text entity can now update camera enc key when changed.

### DIFF
--- a/custom_components/ezviz_cloud/__init__.py
+++ b/custom_components/ezviz_cloud/__init__.py
@@ -17,7 +17,6 @@ from homeassistant.const import (
     CONF_TIMEOUT,
     CONF_TYPE,
     CONF_URL,
-    CONF_USERNAME,
     Platform,
 )
 from homeassistant.core import HomeAssistant
@@ -146,12 +145,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if entry.version == 1:
         if entry.data[CONF_TYPE] == ATTR_TYPE_CAMERA:
-            data = {
-                CONF_USERNAME: entry.data[CONF_USERNAME],
-                CONF_PASSWORD: entry.data[CONF_PASSWORD],
-                CONF_ENC_KEY: entry.data[CONF_PASSWORD],
-                CONF_TYPE: ATTR_TYPE_CAMERA,
-            }
+            data = {**entry.data}
+            data[CONF_ENC_KEY] = entry.data[CONF_PASSWORD]
 
             hass.config_entries.async_update_entry(entry, data=data, version=2)
 

--- a/custom_components/ezviz_cloud/manifest.json
+++ b/custom_components/ezviz_cloud/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/RenierM26/ha-ezviz/issues",
   "loggers": ["paho_mqtt", "pyezvizapi"],
   "requirements": ["pyezvizapi==1.0.0.0"],
-  "version": "0.1.0.46"
+  "version": "0.1.0.47"
 }


### PR DESCRIPTION
While the text entity doesn't regularly poll, this change will allow it to update the config_entry if the enc key changed.

It won't reload any entities so the "cloud entity" still needs a manual reload for it to take effect.