### PR TITLE
Improve entity state

### DIFF
--- a/custom_components/ezviz_cloud/binary_sensor.py
+++ b/custom_components/ezviz_cloud/binary_sensor.py
@@ -29,6 +29,7 @@ BINARY_SENSOR_TYPES: dict[str, BinarySensorEntityDescription] = {
     "encrypted": BinarySensorEntityDescription(
         key="encrypted",
         translation_key="encrypted",
+        entity_registry_enabled_default=False,
     ),
 }
 

--- a/custom_components/ezviz_cloud/camera.py
+++ b/custom_components/ezviz_cloud/camera.py
@@ -147,11 +147,6 @@ class EzvizCamera(EzvizEntity, Camera):
             self._attr_supported_features = CameraEntityFeature.STREAM
 
     @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.data["status"] != 2
-
-    @property
     def is_on(self) -> bool:
         """Return true if on."""
         return bool(self.data["status"])

--- a/custom_components/ezviz_cloud/config_flow.py
+++ b/custom_components/ezviz_cloud/config_flow.py
@@ -68,7 +68,7 @@ def _test_camera_rtsp_creds(data: dict) -> None:
     test_rtsp.main()
 
 
-def _wake_camera(data: dict, ezviz_client) -> None:
+def _wake_camera(data: dict, ezviz_client: EzvizClient) -> None:
     """Wake up hibernating camera and test."""
 
     # Wake hybernating camera.

--- a/custom_components/ezviz_cloud/const.py
+++ b/custom_components/ezviz_cloud/const.py
@@ -22,7 +22,7 @@ EU_URL = "apiieu.ezvizlife.com"
 RUSSIA_URL = "apirus.ezvizru.com"
 DEFAULT_CAMERA_USERNAME = "admin"
 DEFAULT_TIMEOUT = 25
-DEFAULT_FFMPEG_ARGUMENTS = ""
+DEFAULT_FFMPEG_ARGUMENTS = "/Streaming/Channels/102"
 
 # Data
 DATA_COORDINATOR = "coordinator"

--- a/custom_components/ezviz_cloud/entity.py
+++ b/custom_components/ezviz_cloud/entity.py
@@ -77,3 +77,8 @@ class EzvizBaseEntity(Entity):
     def data(self) -> dict[str, Any]:
         """Return coordinator data for this entity."""
         return self.coordinator.data[self._serial]
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.data["status"] != 2

--- a/custom_components/ezviz_cloud/image.py
+++ b/custom_components/ezviz_cloud/image.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 
+from propcache import cached_property
 from pyezvizapi.exceptions import PyEzvizError
 from pyezvizapi.utils import decrypt_image
 
@@ -60,6 +61,11 @@ class EzvizLastMotion(EzvizEntity, ImageEntity):
             if camera and camera.source != SOURCE_IGNORE
             else None
         )
+
+    @cached_property
+    def available(self) -> bool:
+        """Entity gets data from ezviz API so always available."""
+        return True
 
     async def _async_load_image_from_url(self, url: str) -> Image | None:
         """Load an image by url."""

--- a/custom_components/ezviz_cloud/manifest.json
+++ b/custom_components/ezviz_cloud/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/RenierM26/ha-ezviz/issues",
   "loggers": ["paho_mqtt", "pyezvizapi"],
   "requirements": ["pyezvizapi==1.0.0.6"],
-  "version": "0.1.0.53"
+  "version": "0.1.0.54"
 }


### PR DESCRIPTION
- Camera entities depend on the camera being available. Entities will now follow device state (on-line or not)
- Image entity is independent of camera state.
- Typing fix.
- Disable encryption binary sensor by default. (there's a switch for this now)
- Set cameras to use sub stream by default when added. (can be changed, won't change existing cameras)