### PR TITLE
Cleanup camera entity, add motion detection switch.

### DIFF
--- a/custom_components/ezviz_cloud/camera.py
+++ b/custom_components/ezviz_cloud/camera.py
@@ -165,7 +165,7 @@ class EzvizCamera(EzvizEntity, Camera):
             f"{self.data['local_ip']}:{self.data['local_rtsp_port']}{self._ffmpeg_arguments}"
         )
 
-        _LOGGER.warning(
+        _LOGGER.debug(
             "Configuring Camera %s with ip: %s rtsp port: %s ffmpeg arguments: %s",
             self._serial,
             self.data["local_ip"],

--- a/custom_components/ezviz_cloud/strings.json
+++ b/custom_components/ezviz_cloud/strings.json
@@ -125,7 +125,8 @@
       "encrypted": { "name": "Encryption" },
       "push_notify_alarm": { "name": "Alarm push notification" },
       "push_notify_call": { "name": "Call push notification" },
-      "offline_notify": { "name": "Offline notification" }
+      "offline_notify": { "name": "Offline notification" },
+      "motion_detection": { "name": "Motion detection" }
     },
     "siren": { "siren": { "name": "[%key:component::siren::title%]" } }
   },

--- a/custom_components/ezviz_cloud/switch.py
+++ b/custom_components/ezviz_cloud/switch.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from pyezvizapi import EzvizClient
 from pyezvizapi.constants import SupportExt
-from pyezvizapi.exceptions import HTTPError, PyEzvizError
+from pyezvizapi.exceptions import HTTPError, InvalidHost, PyEzvizError
 
 from homeassistant.components.switch import (
     SwitchDeviceClass,
@@ -204,6 +204,15 @@ SWITCH_TYPES: dict[int | str, EzvizSwitchEntityDescription] = {
         enable: pyezviz_client.set_offline_notification(serial, enable),
         switch_state=lambda data: data["offline_notify"],
     ),
+    "alarm_notify": EzvizSwitchEntityDescription(
+        key="motion_detection",
+        translation_key="motion_detection",
+        supported_ext=None,
+        method=lambda pyezviz_client, serial, enable: pyezviz_client.set_camera_defence(
+            serial, enable
+        ),
+        switch_state=lambda data: data["alarm_notify"],
+    ),
 }
 
 
@@ -263,7 +272,7 @@ class EzvizSwitch(EzvizEntity, SwitchEntity):
                 1,
             )
 
-        except (HTTPError, PyEzvizError) as err:
+        except (HTTPError, PyEzvizError, InvalidHost) as err:
             raise HomeAssistantError(f"Failed to turn on switch {self.name}") from err
 
         self._attr_is_on = True
@@ -279,7 +288,7 @@ class EzvizSwitch(EzvizEntity, SwitchEntity):
                 0,
             )
 
-        except (HTTPError, PyEzvizError) as err:
+        except (HTTPError, PyEzvizError, InvalidHost) as err:
             raise HomeAssistantError(f"Failed to turn on switch {self.name}") from err
 
         self._attr_is_on = False

--- a/custom_components/ezviz_cloud/translations/en.json
+++ b/custom_components/ezviz_cloud/translations/en.json
@@ -206,6 +206,9 @@
       },
       "voice_prompt": {
         "name": "Voice prompt"
+      },
+      "motion_detection": {
+        "name": "Motion detection"
       }
     }
   },


### PR DESCRIPTION
Most new battery cameras don't support rtsp streams, added switch to enable/disable camera for those cases. (if you choose to ignore camera)

*Breaking change for a specific scenario*:
 - Ignored or not configured camera entities will now be orphaned or not created. Use the motion detection switch to manage motion detection.