### PR TITLE
Improve logic for camera password and/or encryption key

### DIFF
--- a/custom_components/ezviz_cloud/__init__.py
+++ b/custom_components/ezviz_cloud/__init__.py
@@ -28,6 +28,7 @@ from .const import (
     CONF_ENC_KEY,
     CONF_FFMPEG_ARGUMENTS,
     CONF_RF_SESSION_ID,
+    CONF_RTSP_USES_VERIFICATION_CODE,
     CONF_SESSION_ID,
     DATA_COORDINATOR,
     DEFAULT_FFMPEG_ARGUMENTS,
@@ -149,6 +150,25 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if not entry.data.get(CONF_SESSION_ID):
                 raise ConfigEntryAuthFailed
             hass.config_entries.async_update_entry(entry, data=entry.data, version=2)
+
+        _LOGGER.info(
+            "Migration to version %s.%s successful for %s account",
+            entry.version,
+            entry.minor_version,
+            entry.data[CONF_TYPE],
+        )
+
+    if entry.version != 3:
+        if entry.data[CONF_TYPE] == ATTR_TYPE_CAMERA:
+            data = {**entry.data}
+            data[CONF_RTSP_USES_VERIFICATION_CODE] = True
+
+            hass.config_entries.async_update_entry(entry, data=data, version=3)
+
+        if entry.data[CONF_TYPE] == ATTR_TYPE_CLOUD:
+            if not entry.data.get(CONF_SESSION_ID):
+                raise ConfigEntryAuthFailed
+            hass.config_entries.async_update_entry(entry, data=entry.data, version=3)
 
         _LOGGER.info(
             "Migration to version %s.%s successful for %s account",

--- a/custom_components/ezviz_cloud/camera.py
+++ b/custom_components/ezviz_cloud/camera.py
@@ -25,7 +25,9 @@ from homeassistant.helpers.entity_platform import (
 
 from .const import (
     ATTR_SERIAL,
+    CONF_ENC_KEY,
     CONF_FFMPEG_ARGUMENTS,
+    CONF_RTSP_USES_VERIFICATION_CODE,
     DATA_COORDINATOR,
     DOMAIN,
     SERVICE_WAKE_DEVICE,
@@ -81,7 +83,9 @@ async def async_setup_entry(
                 coordinator,
                 camera,
                 camera_config_entry.data[CONF_USERNAME],
-                camera_config_entry.data[CONF_PASSWORD],
+                camera_config_entry.data[CONF_PASSWORD]
+                if not camera_config_entry.data[CONF_RTSP_USES_VERIFICATION_CODE]
+                else camera_config_entry.data[CONF_ENC_KEY],
                 camera_config_entry.options[CONF_FFMPEG_ARGUMENTS],
             )
         )

--- a/custom_components/ezviz_cloud/const.py
+++ b/custom_components/ezviz_cloud/const.py
@@ -13,6 +13,7 @@ CONF_RF_SESSION_ID = "rf_session_id"
 CONF_EZVIZ_ACCOUNT = "ezviz_account"
 CONF_ENC_KEY = "enc_key"
 CONF_TEST_RTSP_CREDENTIALS = "test_rtsp_credentials"
+CONF_RTSP_USES_VERIFICATION_CODE = "rtsp_uses_verification_code"
 
 # Service names
 SERVICE_WAKE_DEVICE = "wake_device"

--- a/custom_components/ezviz_cloud/const.py
+++ b/custom_components/ezviz_cloud/const.py
@@ -14,6 +14,8 @@ CONF_EZVIZ_ACCOUNT = "ezviz_account"
 CONF_ENC_KEY = "enc_key"
 CONF_TEST_RTSP_CREDENTIALS = "test_rtsp_credentials"
 CONF_RTSP_USES_VERIFICATION_CODE = "rtsp_uses_verification_code"
+CONF_CAM_VERIFICATION_2FA_CODE = "cam_verification_2fa_code"
+CONF_CAM_ENC_2FA_CODE = "cam_encryption_2fa_code"
 
 # Service names
 SERVICE_WAKE_DEVICE = "wake_device"

--- a/custom_components/ezviz_cloud/manifest.json
+++ b/custom_components/ezviz_cloud/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/RenierM26/ha-ezviz/issues",
   "loggers": ["paho_mqtt", "pyezvizapi"],
-  "requirements": ["pyezvizapi==1.0.1.3"],
+  "requirements": ["pyezvizapi==1.0.1.6"],
   "version": "0.1.0.64"
 }

--- a/custom_components/ezviz_cloud/manifest.json
+++ b/custom_components/ezviz_cloud/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/RenierM26/ha-ezviz/issues",
   "loggers": ["paho_mqtt", "pyezvizapi"],
   "requirements": ["pyezvizapi==1.0.1.6"],
-  "version": "0.1.0.64"
+  "version": "0.1.0.65"
 }

--- a/custom_components/ezviz_cloud/strings.json
+++ b/custom_components/ezviz_cloud/strings.json
@@ -25,6 +25,8 @@
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
+          "enc_key": "Encryption key",
+          "rtsp_uses_verification_code": "Camera uses sticker verification code for video stream",
           "test_rtsp_credentials": "Test RTSP credentials"
         }
       },

--- a/custom_components/ezviz_cloud/strings.json
+++ b/custom_components/ezviz_cloud/strings.json
@@ -33,7 +33,10 @@
       "async_step_confirm_2FA": {
         "title": "EZVIZ camera encryption key",
         "description": "Enter MFA code to fetch encryption key for EZVIZ camera {serial} with IP {ip_address}",
-        "data": { "sms_code": "MFA Code" }
+        "data": {
+          "cam_verification_2fa_code": "DEVICE_AUTH_CODE 2FA code from email if required",
+          "cam_encryption_2fa_code": "DEVICE_ENCRYPTION 2FA code from email if required"
+        }
       },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
@@ -58,7 +61,8 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
-      "mfa_required": "2FA enabled on account, please disable and retry"
+      "mfa_required": "2FA enabled on account, please disable and retry",
+      "device_exception": "Device exception, couldn't fetch key"
     },
     "abort": {
       "already_configured_account": "[%key:common::config_flow::abort::already_configured_account%]",

--- a/custom_components/ezviz_cloud/strings.json
+++ b/custom_components/ezviz_cloud/strings.json
@@ -30,6 +30,11 @@
           "test_rtsp_credentials": "Test RTSP credentials"
         }
       },
+      "async_step_confirm_2FA": {
+        "title": "EZVIZ camera encryption key",
+        "description": "Enter MFA code to fetch encryption key for EZVIZ camera {serial} with IP {ip_address}",
+        "data": { "sms_code": "MFA Code" }
+      },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
         "description": "Enter credentials to reauthenticate to ezviz cloud account",

--- a/custom_components/ezviz_cloud/translations/en.json
+++ b/custom_components/ezviz_cloud/translations/en.json
@@ -25,6 +25,11 @@
         "description": "Enter RTSP credentials for EZVIZ camera {serial} with IP {ip_address}",
         "title": "Discovered EZVIZ Camera"
       },
+      "async_step_confirm_2FA": {
+        "title": "EZVIZ camera encryption key",
+        "description": "Enter MFA code to fetch encryption key for EZVIZ camera {serial} with IP {ip_address}",
+        "data": { "sms_code": "MFA Code" }
+      },
       "reauth_confirm": {
         "data": {
           "password": "Password",

--- a/custom_components/ezviz_cloud/translations/en.json
+++ b/custom_components/ezviz_cloud/translations/en.json
@@ -18,6 +18,8 @@
         "data": {
           "password": "Password",
           "username": "Username",
+          "enc_key": "Encryption key",
+          "rtsp_uses_verification_code": "Camera uses sticker verification code for video stream",
           "test_rtsp_credentials": "Test RTSP credentials"
         },
         "description": "Enter RTSP credentials for EZVIZ camera {serial} with IP {ip_address}",

--- a/custom_components/ezviz_cloud/translations/en.json
+++ b/custom_components/ezviz_cloud/translations/en.json
@@ -10,7 +10,8 @@
       "cannot_connect": "Failed to connect",
       "invalid_auth": "Invalid authentication",
       "invalid_host": "Invalid hostname or IP address",
-      "mfa_required": "2FA enabled on account, please disable and retry"
+      "mfa_required": "2FA enabled on account, please disable and retry",
+      "device_exception": "Device exception, couldn't fetch key"
     },
     "flow_title": "{serial}",
     "step": {
@@ -28,7 +29,10 @@
       "async_step_confirm_2FA": {
         "title": "EZVIZ camera encryption key",
         "description": "Enter MFA code to fetch encryption key for EZVIZ camera {serial} with IP {ip_address}",
-        "data": { "sms_code": "MFA Code" }
+        "data": {
+          "cam_verification_2fa_code": "DEVICE_AUTH_CODE 2FA code from email if required",
+          "cam_encryption_2fa_code": "DEVICE_ENCRYPTION 2FA code from email if required"
+        }
       },
       "reauth_confirm": {
         "data": {


### PR DESCRIPTION
- Config flow setting for Camera used encryption key or sticker code for RTSP stream.
- Fix non 2FA account config for Camera passwords.
- Bump version with new variable. This allows for different password for stream and encrypted images. 