### PR TITLE
Migrate entity ids for legacy entities that use camera name.

### DIFF
--- a/custom_components/ezviz_cloud/binary_sensor.py
+++ b/custom_components/ezviz_cloud/binary_sensor.py
@@ -29,16 +29,8 @@ class EzvizBinarySensorEntityDescription(BinarySensorEntityDescription):
     """EZVIZ binary sensor description with value, capability & device-category gating."""
 
     value_fn: Callable[[dict[str, Any]], bool]
-
-    # Capability gating via camera_data["supportExt"].
-    # If supported_ext_key is None -> always supported (subject to device-category).
-    # If set -> camera_data["supportExt"][supported_ext_key] must equal one of the raw strings
-    # in supported_ext_value (e.g., ["1,2,3", "2", "3"]).
     supported_ext_key: str | None = None
     supported_ext_value: list[str] | None = None
-
-    # Device-category gating via camera_data["device_category"].
-    # None => no gating; tuple => must match one of these categories exactly.
     required_device_categories: tuple[str, ...] | None = None
 
 
@@ -106,7 +98,6 @@ async def async_setup_entry(
         DATA_COORDINATOR
     ]
 
-    # Registry unique_id migration: "<serial>_<camera name>.<key>" -> "{serial}_{key}"
     await migrate_unique_ids_with_coordinator(
         hass=hass,
         entry=entry,
@@ -142,7 +133,6 @@ class EzvizBinarySensor(EzvizEntity, BinarySensorEntity):
         """Initialize the binary_sensor."""
         super().__init__(coordinator, serial)
         self.entity_description = description
-        # Stable unique_id: "{serial}_{key}" (no camera name)
         self._attr_unique_id = f"{serial}_{description.key}"
 
     @property

--- a/custom_components/ezviz_cloud/binary_sensor.py
+++ b/custom_components/ezviz_cloud/binary_sensor.py
@@ -2,73 +2,135 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DATA_COORDINATOR, DOMAIN
 from .coordinator import EzvizDataUpdateCoordinator
 from .entity import EzvizEntity
+from .migration import migrate_unique_ids_with_coordinator
 
 PARALLEL_UPDATES = 1
 
-BINARY_SENSOR_TYPES: dict[str, BinarySensorEntityDescription] = {
-    "Motion_Trigger": BinarySensorEntityDescription(
+
+@dataclass(frozen=True, kw_only=True)
+class EzvizBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """EZVIZ binary sensor description with value & capability gating."""
+
+    value_fn: Callable[[dict], bool]
+    supported_ext_key: str | None = None
+    supported_ext_value: tuple[str, ...] | None = None
+
+
+def _is_desc_supported(
+    camera_data: dict, desc: EzvizBinarySensorEntityDescription
+) -> bool:
+    """Return True if this entity description is supported by the camera."""
+    # No gating configured: always supported
+    if desc.supported_ext_key is None and desc.supported_ext_value is None:
+        return True
+
+    support_ext = camera_data.get("supportExt") or {}
+    if not isinstance(support_ext, dict):
+        return False
+
+    current_val = support_ext.get(desc.supported_ext_key)
+    if current_val is None:
+        return False
+
+    # If supported_ext_value is None -> presence of the key is enough
+    if desc.supported_ext_value is None:
+        return True
+
+    return str(current_val) in desc.supported_ext_value
+
+
+BINARY_SENSORS: tuple[EzvizBinarySensorEntityDescription, ...] = (
+    EzvizBinarySensorEntityDescription(
         key="Motion_Trigger",
+        translation_key="motion_trigger",
         device_class=BinarySensorDeviceClass.MOTION,
+        value_fn=lambda d: bool(d.get("Motion_Trigger")),
+        supported_ext_key=None,
+        supported_ext_value=None,
     ),
-    "alarm_schedules_enabled": BinarySensorEntityDescription(
+    EzvizBinarySensorEntityDescription(
         key="alarm_schedules_enabled",
         translation_key="alarm_schedules_enabled",
+        value_fn=lambda d: bool(d.get("alarm_schedules_enabled")),
+        supported_ext_key=None,
+        supported_ext_value=None,
     ),
-    "encrypted": BinarySensorEntityDescription(
+    EzvizBinarySensorEntityDescription(
         key="encrypted",
         translation_key="encrypted",
         entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda d: bool(d.get("encrypted")),
+        supported_ext_key=None,
+        supported_ext_value=None,
     ),
-}
+)
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up EZVIZ sensors based on a config entry."""
+    """Set up EZVIZ binary sensors from a config entry."""
     coordinator: EzvizDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
         DATA_COORDINATOR
     ]
 
-    async_add_entities(
-        [
-            EzvizBinarySensor(coordinator, camera, binary_sensor)
-            for camera in coordinator.data
-            for binary_sensor, value in coordinator.data[camera].items()
-            if binary_sensor in BINARY_SENSOR_TYPES
-            if value is not None
-        ]
+    # One-time registry migration: "<serial>_<camera name>.<key>" -> "{serial}_{key}"
+    await migrate_unique_ids_with_coordinator(
+        hass=hass,
+        entry=entry,
+        coordinator=coordinator,
+        platform_domain="binary_sensor",
+        allowed_keys=tuple(desc.key for desc in BINARY_SENSORS),
+        mark_once_option="uid_migrated_v1_binary_sensor",
     )
+
+    entities: list[EzvizBinarySensor] = []
+    for serial, camera_data in coordinator.data.items():
+        for desc in BINARY_SENSORS:
+            if not _is_desc_supported(camera_data, desc):
+                continue
+            if desc.key in camera_data and camera_data[desc.key] is not None:
+                entities.append(EzvizBinarySensor(coordinator, serial, desc))
+
+    if entities:
+        async_add_entities(entities)
 
 
 class EzvizBinarySensor(EzvizEntity, BinarySensorEntity):
-    """Representation of a EZVIZ sensor."""
+    """Representation of an EZVIZ binary sensor."""
+
+    _attr_has_entity_name = True
+    entity_description: EzvizBinarySensorEntityDescription
 
     def __init__(
         self,
         coordinator: EzvizDataUpdateCoordinator,
         serial: str,
-        binary_sensor: str,
+        description: EzvizBinarySensorEntityDescription,
     ) -> None:
-        """Initialize the sensor."""
+        """Initialize the binary sensor."""
         super().__init__(coordinator, serial)
-        self._sensor_name = binary_sensor
-        self._attr_unique_id = f"{serial}_{self._camera_name}.{binary_sensor}"
-        self.entity_description = BINARY_SENSOR_TYPES[binary_sensor]
+        self.entity_description = description
+        self._attr_unique_id = f"{serial}_{description.key}"
 
     @property
     def is_on(self) -> bool:
-        """Return the state of the sensor."""
-        return bool(self.data[self._sensor_name])
+        """Return the sensor state."""
+        return self.entity_description.value_fn(self.data)

--- a/custom_components/ezviz_cloud/binary_sensor.py
+++ b/custom_components/ezviz_cloud/binary_sensor.py
@@ -101,7 +101,7 @@ BINARY_SENSORS: tuple[EzvizBinarySensorEntityDescription, ...] = (
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up EZVIZ binary sensors from a config entry."""
+    """Set up EZVIZ binary sensors from coordinator data."""
     coordinator: EzvizDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
         DATA_COORDINATOR
     ]

--- a/custom_components/ezviz_cloud/binary_sensor.py
+++ b/custom_components/ezviz_cloud/binary_sensor.py
@@ -106,16 +106,12 @@ async def async_setup_entry(
         allowed_keys=tuple(desc.key for desc in BINARY_SENSORS),
     )
 
-    entities: list[EzvizBinarySensor] = []
-    for serial, camera_data in coordinator.data.items():
-        for desc in BINARY_SENSORS:
-            if not _is_desc_supported(camera_data, desc):
-                continue
-            if desc.key in camera_data and camera_data[desc.key] is not None:
-                entities.append(EzvizBinarySensor(coordinator, serial, desc))
-
-    if entities:
-        async_add_entities(entities)
+    async_add_entities(
+        EzvizBinarySensor(coordinator, serial, desc)
+        for serial, camera_data in coordinator.data.items()
+        for desc in BINARY_SENSORS
+        if _is_desc_supported(camera_data, desc)
+    )
 
 
 class EzvizBinarySensor(EzvizEntity, BinarySensorEntity):

--- a/custom_components/ezviz_cloud/migration.py
+++ b/custom_components/ezviz_cloud/migration.py
@@ -1,0 +1,255 @@
+"""Entity-registry unique_id migration utilities for ha-ezviz.
+
+Migrate legacy unique_ids that embed the camera name to the stable format:
+
+    "<SERIAL>_<CAMERA NAME>.<KEY>"  →  "<SERIAL>_<KEY>"
+
+This version STRICTLY verifies the camera name in the UID matches the
+current coordinator-provided name (case/space-normalized). Mismatches
+are skipped and listed in a Repairs issue.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+import logging
+import re
+import time
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
+
+from .const import DOMAIN
+from .coordinator import EzvizDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Only migrate name-bearing legacy UIDs of the form:
+# "<SERIAL>_<CAMERA NAME>.<KEY>"
+LEGACY_UID_REGEX = re.compile(
+    r"^(?P<serial>[A-Za-z0-9]+)_(?P<camera_name>.+)\.(?P<key>[^.]+)$"
+)
+
+
+@dataclass
+class MigrationStats:
+    """Counters for a migration pass."""
+
+    examined: int = 0
+    migrated: int = 0
+    skipped_bad_format: int = 0  # doesn't match "<serial>_<name>.<key>"
+    skipped_unknown_serial: int = 0  # serial not in coordinator.data
+    skipped_name_mismatch: int = 0  # camera name in UID != coordinator name
+    skipped_key_not_allowed: int = 0  # key not in allowlist
+    skipped_key_not_present: int = 0  # key not present in camera data
+    skipped_collision: int = 0  # target UID already taken
+
+
+def _norm_name(value: str | None) -> str | None:
+    """Normalize camera names for comparison (case/whitespace-insensitive)."""
+    if not value:
+        return None
+    return " ".join(value.strip().lower().split())
+
+
+async def migrate_unique_ids_with_coordinator(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: EzvizDataUpdateCoordinator,
+    *,
+    platform_domain: str,  # "sensor", "binary_sensor", "switch"
+    allowed_keys: Iterable[str],  # valid entity description keys for this platform
+    key_renames: Mapping[str, str] | None = None,  # optional: map old_key -> new_key
+    mark_once_option: str | None = None,  # e.g. "uid_migrated_v1_sensor"
+) -> MigrationStats:
+    """Migrate legacy unique_ids for one platform using coordinator data.
+
+    Strict rules:
+      - UID must match "<serial>_<camera name>.<key>".
+      - Serial must exist in coordinator.data.
+      - Camera name in UID must equal current coordinator name (normalized).
+      - Key must be in `allowed_keys` and present for that camera.
+      - Renames via `key_renames` are applied before validation.
+      - Disabled entities are migrated as well (state unchanged).
+      - Skips are summarized in a Repairs issue; the issue is cleared when clean.
+    """
+    stats = MigrationStats()
+
+    # Optional run-once guard per entry+platform
+    if mark_once_option and entry.options.get(mark_once_option):
+        return stats
+
+    entity_registry = er.async_get(hass)
+    devices_by_serial: dict[str, dict[str, Any]] = coordinator.data or {}
+
+    allowed_key_set = set(allowed_keys)
+    rename_map = dict(key_renames or {})
+
+    skipped_entity_ids: list[str] = []
+
+    def compute_change(reg_entry: er.RegistryEntry) -> dict[str, Any] | None:
+        nonlocal stats
+
+        # Only act on our integration + requested HA platform
+        if reg_entry.platform != DOMAIN or reg_entry.domain != platform_domain:
+            return None
+
+        old_uid = reg_entry.unique_id
+        stats.examined += 1
+
+        # Already in new scheme (no dot: "<serial>_<key>") → nothing to do
+        if "." not in old_uid:
+            return None
+
+        match = LEGACY_UID_REGEX.match(old_uid)
+        if not match:
+            stats.skipped_bad_format += 1
+            skipped_entity_ids.append(reg_entry.entity_id)
+            return None
+
+        serial_in_uid = match.group("serial")
+        name_in_uid = match.group("camera_name")
+        key_in_uid = match.group("key")
+
+        # Serial must exist
+        camera_data = devices_by_serial.get(serial_in_uid)
+        if camera_data is None:
+            stats.skipped_unknown_serial += 1
+            skipped_entity_ids.append(reg_entry.entity_id)
+            return None
+
+        # Camera name must match coordinator (normalized)
+        current_name = _norm_name(camera_data.get("name"))
+        uid_name_norm = _norm_name(name_in_uid)
+        if not current_name or not uid_name_norm or uid_name_norm != current_name:
+            stats.skipped_name_mismatch += 1
+            skipped_entity_ids.append(reg_entry.entity_id)
+            return None
+
+        # Map/validate key
+        effective_key = rename_map.get(key_in_uid, key_in_uid)
+        if effective_key not in allowed_key_set:
+            stats.skipped_key_not_allowed += 1
+            skipped_entity_ids.append(reg_entry.entity_id)
+            return None
+
+        # Key must exist in this camera's dict (top-level)
+        if effective_key not in camera_data:
+            stats.skipped_key_not_present += 1
+            skipped_entity_ids.append(reg_entry.entity_id)
+            return None
+
+        new_uid = f"{serial_in_uid}_{effective_key}"
+        if new_uid == old_uid:
+            return None  # nothing to change
+
+        # Avoid collisions
+        existing_entity_id = entity_registry.async_get_entity_id(
+            reg_entry.domain, reg_entry.platform, new_uid
+        )
+        if existing_entity_id and existing_entity_id != reg_entry.entity_id:
+            stats.skipped_collision += 1
+            skipped_entity_ids.append(reg_entry.entity_id)
+            _LOGGER.warning(
+                "Unique ID migration collision for %s: %s -> %s (already used by %s)",
+                reg_entry.entity_id,
+                old_uid,
+                new_uid,
+                existing_entity_id,
+            )
+            return None
+
+        _LOGGER.debug(
+            "Migrating unique_id for %s: %s -> %s",
+            reg_entry.entity_id,
+            old_uid,
+            new_uid,
+        )
+        stats.migrated += 1
+        return {"new_unique_id": new_uid}
+
+    # Perform migration across all entities in the config entry
+    await er.async_migrate_entries(hass, entry.entry_id, compute_change)
+
+    # Optional run-once marker (store summary)
+    if mark_once_option:
+        opts = dict(entry.options)
+        opts[mark_once_option] = {
+            "ts": int(time.time()),
+            "platform": platform_domain,
+            "examined": stats.examined,
+            "migrated": stats.migrated,
+            "skipped_bad_format": stats.skipped_bad_format,
+            "skipped_unknown_serial": stats.skipped_unknown_serial,
+            "skipped_name_mismatch": stats.skipped_name_mismatch,
+            "skipped_key_not_allowed": stats.skipped_key_not_allowed,
+            "skipped_key_not_present": stats.skipped_key_not_present,
+            "skipped_collision": stats.skipped_collision,
+        }
+        hass.config_entries.async_update_entry(entry, options=opts)
+
+    # Repairs issue: create/update when there are skips; delete when clean
+    issue_id = f"uid_migration_review_{platform_domain}_{entry.entry_id}"
+    total_skipped = (
+        stats.skipped_bad_format
+        + stats.skipped_unknown_serial
+        + stats.skipped_name_mismatch
+        + stats.skipped_key_not_allowed
+        + stats.skipped_key_not_present
+        + stats.skipped_collision
+    )
+
+    if total_skipped:
+        example_ids = sorted(set(skipped_entity_ids))[:20]
+        examples_text = (
+            "\n".join(f"- {eid}" for eid in example_ids) if example_ids else ""
+        )
+
+        async_create_issue(
+            hass=hass,
+            domain=DOMAIN,
+            issue_id=issue_id,
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="uid_migration_review",
+            translation_placeholders={
+                "platform": platform_domain,
+                "examined": str(stats.examined),
+                "migrated": str(stats.migrated),
+                "count_bad_format": str(stats.skipped_bad_format),
+                "count_unknown_serial": str(stats.skipped_unknown_serial),
+                "count_name_mismatch": str(getattr(stats, "skipped_name_mismatch", 0)),
+                "count_key_not_allowed": str(stats.skipped_key_not_allowed),
+                "count_key_not_present": str(stats.skipped_key_not_present),
+                "count_collision": str(stats.skipped_collision),
+                "examples": examples_text,
+            },
+        )
+    else:
+        async_delete_issue(hass, DOMAIN, issue_id)
+
+    # Log summary
+    log_fn = _LOGGER.info if stats.migrated else _LOGGER.debug
+    log_fn(
+        "[%s] UID migration: migrated=%s examined=%s "
+        "(bad_format=%s unknown_serial=%s name_mismatch=%s key_not_allowed=%s key_not_present=%s collisions=%s)",
+        platform_domain,
+        stats.migrated,
+        stats.examined,
+        stats.skipped_bad_format,
+        stats.skipped_unknown_serial,
+        stats.skipped_name_mismatch,
+        stats.skipped_key_not_allowed,
+        stats.skipped_key_not_present,
+        stats.skipped_collision,
+    )
+
+    return stats

--- a/custom_components/ezviz_cloud/sensor.py
+++ b/custom_components/ezviz_cloud/sensor.py
@@ -121,8 +121,6 @@ SENSORS: tuple[EzvizSensorEntityDescription, ...] = (
         key="PIR_Status",
         translation_key="pir_status",
         value_fn=lambda d: d.get("PIR_Status"),
-        # Example:
-        # supported_ext_key="456", supported_ext_value=["1", "3"]
     ),
     EzvizSensorEntityDescription(
         key="last_alarm_type_code",

--- a/custom_components/ezviz_cloud/sensor.py
+++ b/custom_components/ezviz_cloud/sensor.py
@@ -157,16 +157,12 @@ async def async_setup_entry(
         allowed_keys=tuple(desc.key for desc in SENSORS),
     )
 
-    entities: list[EzvizSensor] = []
-    for serial, camera_data in coordinator.data.items():
-        for desc in SENSORS:
-            if not _is_desc_supported(camera_data, desc):
-                continue
-            if desc.key in camera_data and camera_data[desc.key] is not None:
-                entities.append(EzvizSensor(coordinator, serial, desc))
-
-    if entities:
-        async_add_entities(entities)
+    async_add_entities(
+        EzvizSensor(coordinator, serial, desc)
+        for serial, camera_data in coordinator.data.items()
+        for desc in SENSORS
+        if _is_desc_supported(camera_data, desc)
+    )
 
 
 class EzvizSensor(EzvizEntity, SensorEntity):

--- a/custom_components/ezviz_cloud/sensor.py
+++ b/custom_components/ezviz_cloud/sensor.py
@@ -172,7 +172,7 @@ async def async_setup_entry(
 
 
 class EzvizSensor(EzvizEntity, SensorEntity):
-    """Representation of an EZVIZ sensor."""
+    """Set up EZVIZ sensors from coordinator data."""
 
     _attr_has_entity_name = True
     entity_description: EzvizSensorEntityDescription

--- a/custom_components/ezviz_cloud/strings.json
+++ b/custom_components/ezviz_cloud/strings.json
@@ -269,5 +269,11 @@
         "custom": "Custom host"
       }
     }
+  },
+  "issues": {
+    "uid_migration_review": {
+      "title": "Review skipped {platform} unique_id migrations",
+      "description": "Some legacy entities could not be migrated to the new unique_id format and were left unchanged.\n\nExamined: {examined}\nMigrated: {migrated}\nSkipped (bad format): {count_bad_format}\nSkipped (unknown serial): {count_unknown_serial}\nSkipped (camera name mismatch): {count_name_mismatch}\nSkipped (key not allowed): {count_key_not_allowed}\nSkipped (key not present): {count_key_not_present}\nSkipped (collision): {count_collision}\n\n{examples}"
+    }
   }
 }

--- a/custom_components/ezviz_cloud/switch.py
+++ b/custom_components/ezviz_cloud/switch.py
@@ -78,14 +78,18 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         supported_ext_key=str(SupportExt.SupportAlarmVoice.value),
         supported_ext_value=None,
         value_fn=lambda d: (d.get("switches") or {}).get(1),
-        method=lambda client, serial, enable: client.switch_status(serial, 1, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.switch_status(
+            serial, 1, enable
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="LIGHT",
         translation_key="status_light",
         device_class=SwitchDeviceClass.SWITCH,
         value_fn=lambda d: (d.get("switches") or {}).get(3),
-        method=lambda client, serial, enable: client.switch_status(serial, 3, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.switch_status(
+            serial, 3, enable
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="PRIVACY",
@@ -93,7 +97,9 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         device_class=SwitchDeviceClass.SWITCH,
         supported_ext_key=str(SupportExt.SupportPtzPrivacy.value),
         value_fn=lambda d: (d.get("switches") or {}).get(7),
-        method=lambda client, serial, enable: client.switch_status(serial, 7, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.switch_status(
+            serial, 7, enable
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="INFRARED_LIGHT",
@@ -101,7 +107,9 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         device_class=SwitchDeviceClass.SWITCH,
         supported_ext_key=str(SupportExt.SupportCloseInfraredLight.value),
         value_fn=lambda d: (d.get("switches") or {}).get(10),
-        method=lambda client, serial, enable: client.switch_status(serial, 10, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.switch_status(
+            serial, 10, enable
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="SLEEP",
@@ -109,7 +117,9 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         device_class=SwitchDeviceClass.SWITCH,
         supported_ext_key=str(SupportExt.SupportSleep.value),
         value_fn=lambda d: (d.get("switches") or {}).get(21),
-        method=lambda client, serial, enable: client.switch_status(serial, 21, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.switch_status(
+            serial, 21, enable
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="SOUND",
@@ -117,7 +127,9 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         device_class=SwitchDeviceClass.SWITCH,
         supported_ext_key=str(SupportExt.SupportAudioOnoff.value),
         value_fn=lambda d: (d.get("switches") or {}).get(22),
-        method=lambda client, serial, enable: client.switch_status(serial, 22, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.switch_status(
+            serial, 22, enable
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="MOBILE_TRACKING",
@@ -125,7 +137,9 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         device_class=SwitchDeviceClass.SWITCH,
         supported_ext_key=str(SupportExt.SupportIntelligentTrack.value),
         value_fn=lambda d: (d.get("switches") or {}).get(25),
-        method=lambda client, serial, enable: client.switch_status(serial, 25, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.switch_status(
+            serial, 25, enable
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="ALL_DAY_VIDEO",
@@ -133,7 +147,9 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         device_class=SwitchDeviceClass.SWITCH,
         supported_ext_key=str(SupportExt.SupportFullDayRecord.value),
         value_fn=lambda d: (d.get("switches") or {}).get(29),
-        method=lambda client, serial, enable: client.switch_status(serial, 29, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.switch_status(
+            serial, 29, enable
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="AUTO_SLEEP",
@@ -141,7 +157,9 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         device_class=SwitchDeviceClass.SWITCH,
         supported_ext_key=str(SupportExt.SupportAutoSleep.value),
         value_fn=lambda d: (d.get("switches") or {}).get(32),
-        method=lambda client, serial, enable: client.switch_status(serial, 32, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.switch_status(
+            serial, 32, enable
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="LIGHT_FLICKER",
@@ -149,7 +167,9 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         device_class=SwitchDeviceClass.SWITCH,
         supported_ext_key=str(SupportExt.SupportActiveDefense.value),
         value_fn=lambda d: (d.get("switches") or {}).get(301),
-        method=lambda client, serial, enable: client.switch_status(serial, 301, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.switch_status(
+            serial, 301, enable
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="ALARM_LIGHT_RELEVANCE",
@@ -157,7 +177,9 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         device_class=SwitchDeviceClass.SWITCH,
         supported_ext_key=str(SupportExt.SupportLightRelate.value),
         value_fn=lambda d: (d.get("switches") or {}).get(305),
-        method=lambda client, serial, enable: client.switch_status(serial, 305, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.switch_status(
+            serial, 305, enable
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="TAMPER_ALARM",
@@ -165,7 +187,9 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         device_class=SwitchDeviceClass.SWITCH,
         supported_ext_key=str(SupportExt.SupportTamperAlarm.value),
         value_fn=lambda d: (d.get("switches") or {}).get(306),
-        method=lambda client, serial, enable: client.switch_status(serial, 306, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.switch_status(
+            serial, 306, enable
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="TRACKING",
@@ -173,14 +197,18 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         device_class=SwitchDeviceClass.SWITCH,
         supported_ext_key=str(SupportExt.SupportTracking.value),
         value_fn=lambda d: (d.get("switches") or {}).get(650),
-        method=lambda client, serial, enable: client.switch_status(serial, 650, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.switch_status(
+            serial, 650, enable
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="WATERMARK",
         translation_key="watermark",
         device_class=SwitchDeviceClass.SWITCH,
         value_fn=lambda d: (d.get("switches") or {}).get(702),
-        method=lambda client, serial, enable: client.switch_status(serial, 702, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.switch_status(
+            serial, 702, enable
+        ),
     ),
     # Top-level flags in camera_data (not under "switches")
     EzvizSwitchEntityDescription(
@@ -188,20 +216,24 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         translation_key="encrypted",
         supported_ext_key=str(SupportExt.SupportEncrypt.value),
         value_fn=lambda d: d.get("encrypted"),
-        method=lambda client, serial, enable: client.set_video_enc(serial, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.set_video_enc(
+            serial, enable
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="push_notify_alarm",
         translation_key="push_notify_alarm",
         value_fn=lambda d: d.get("push_notify_alarm"),
-        method=lambda client, serial, enable: client.do_not_disturb(serial, enable ^ 1),
+        method=lambda ezviz_client, serial, enable: ezviz_client.do_not_disturb(
+            serial, enable ^ 1
+        ),
     ),
     EzvizSwitchEntityDescription(
         key="push_notify_call",
         translation_key="push_notify_call",
         supported_ext_key=str(SupportExt.SupportAlarmVoice.value),
         value_fn=lambda d: d.get("push_notify_call"),
-        method=lambda client, serial, enable: client.set_answer_call(
+        method=lambda ezviz_client, serial, enable: ezviz_client.set_answer_call(
             serial, enable ^ 1
         ),
     ),
@@ -210,16 +242,18 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         translation_key="offline_notify",
         supported_ext_key=str(SupportExt.SupportAlarmVoice.value),
         value_fn=lambda d: d.get("offline_notify"),
-        method=lambda client, serial, enable: client.set_offline_notification(
-            serial, enable
-        ),
+        method=lambda ezviz_client,
+        serial,
+        enable: ezviz_client.set_offline_notification(serial, enable),
     ),
     EzvizSwitchEntityDescription(
         key="motion_detection",
         translation_key="motion_detection",
         supported_ext_key=str(SupportExt.SupportDefence.value),
         value_fn=lambda d: d.get("alarm_notify"),
-        method=lambda client, serial, enable: client.set_camera_defence(serial, enable),
+        method=lambda ezviz_client, serial, enable: ezviz_client.set_camera_defence(
+            serial, enable
+        ),
     ),
 )
 

--- a/custom_components/ezviz_cloud/switch.py
+++ b/custom_components/ezviz_cloud/switch.py
@@ -252,12 +252,17 @@ async def async_setup_entry(
         DATA_COORDINATOR
     ]
 
+    key_renames: dict[str, str] = {
+        "motion_detection": "alarm_notify",  # legacy key -> new canonical key
+    }
+
     await migrate_unique_ids_with_coordinator(
         hass=hass,
         entry=entry,
         coordinator=coordinator,
         platform_domain="switch",
         allowed_keys=tuple(desc.key for desc in SWITCHES),
+        key_renames=key_renames,
         presence_check=_build_switch_presence_check(),
     )
 

--- a/custom_components/ezviz_cloud/switch.py
+++ b/custom_components/ezviz_cloud/switch.py
@@ -215,7 +215,7 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         ),
     ),
     EzvizSwitchEntityDescription(
-        key="alarm_notify",
+        key="motion_detection",
         translation_key="motion_detection",
         supported_ext_key=str(SupportExt.SupportDefence.value),
         value_fn=lambda d: d.get("alarm_notify"),
@@ -232,17 +232,12 @@ async def async_setup_entry(
         DATA_COORDINATOR
     ]
 
-    key_renames: dict[str, str] = {
-        "motion_detection": "alarm_notify",  # legacy key -> new canonical key
-    }
-
     await migrate_unique_ids_with_coordinator(
         hass=hass,
         entry=entry,
         coordinator=coordinator,
         platform_domain="switch",
         allowed_keys=tuple(desc.key for desc in SWITCHES),
-        key_renames=key_renames,
     )
 
     async_add_entities(

--- a/custom_components/ezviz_cloud/switch.py
+++ b/custom_components/ezviz_cloud/switch.py
@@ -224,26 +224,6 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
 )
 
 
-def _build_switch_presence_check() -> Callable[[str, dict[str, Any]], bool]:
-    """Presence check using value_fn (handles nested switches)."""
-    value_fn_by_key: dict[str, Callable[[dict[str, Any]], Any]] = {
-        desc.key: desc.value_fn for desc in SWITCHES
-    }
-
-    def _presence(key: str, camera_data: dict[str, Any]) -> bool:
-        fn = value_fn_by_key.get(key)
-        if fn is None:
-            return False
-        try:
-            value = fn(camera_data)
-        except (KeyError, TypeError, AttributeError):
-            # Bad/missing structure (e.g. camera_data is missing keys or not a dict)
-            return False
-        return value is not None  # treat 0/False as valid presence
-
-    return _presence
-
-
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
@@ -263,7 +243,6 @@ async def async_setup_entry(
         platform_domain="switch",
         allowed_keys=tuple(desc.key for desc in SWITCHES),
         key_renames=key_renames,
-        presence_check=_build_switch_presence_check(),
     )
 
     entities: list[EzvizSwitch] = []

--- a/custom_components/ezviz_cloud/switch.py
+++ b/custom_components/ezviz_cloud/switch.py
@@ -76,7 +76,7 @@ SWITCHES: tuple[EzvizSwitchEntityDescription, ...] = (
         translation_key="voice_prompt",
         device_class=SwitchDeviceClass.SWITCH,
         supported_ext_key=str(SupportExt.SupportAlarmVoice.value),
-        supported_ext_value=None,  # presence of capability is enough
+        supported_ext_value=None,
         value_fn=lambda d: (d.get("switches") or {}).get(1),
         method=lambda client, serial, enable: client.switch_status(serial, 1, enable),
     ),
@@ -245,17 +245,12 @@ async def async_setup_entry(
         key_renames=key_renames,
     )
 
-    entities: list[EzvizSwitch] = []
-    for serial, camera_data in coordinator.data.items():
-        for desc in SWITCHES:
-            if not _is_desc_supported(camera_data, desc):
-                continue
-            state_val = desc.value_fn(camera_data)
-            if state_val is not None:
-                entities.append(EzvizSwitch(coordinator, serial, desc))
-
-    if entities:
-        async_add_entities(entities)
+    async_add_entities(
+        EzvizSwitch(coordinator, serial, desc)
+        for serial, camera_data in coordinator.data.items()
+        for desc in SWITCHES
+        if _is_desc_supported(camera_data, desc)
+    )
 
 
 class EzvizSwitch(EzvizEntity, SwitchEntity):

--- a/custom_components/ezviz_cloud/translations/en.json
+++ b/custom_components/ezviz_cloud/translations/en.json
@@ -269,5 +269,11 @@
         "custom": "Custom host"
       }
     }
+  },
+  "issues": {
+    "uid_migration_review": {
+      "title": "Review skipped {platform} unique_id migrations",
+      "description": "Some legacy entities could not be migrated to the new unique_id format and were left unchanged.\n\nExamined: {examined}\nMigrated: {migrated}\nSkipped (bad format): {count_bad_format}\nSkipped (unknown serial): {count_unknown_serial}\nSkipped (camera name mismatch): {count_name_mismatch}\nSkipped (key not allowed): {count_key_not_allowed}\nSkipped (key not present): {count_key_not_present}\nSkipped (collision): {count_collision}\n\n{examples}"
+    }
   }
 }


### PR DESCRIPTION
- Entity uniqueid should be unique. Currently renaming a camera causes problems, this pull aims to fix that.