### PR TITLE
Option to generate fake MAC addresses when not returned by EZVIZ official API

### DIFF
--- a/custom_components/ezviz_cloud/__init__.py
+++ b/custom_components/ezviz_cloud/__init__.py
@@ -44,6 +44,9 @@ from .const import (
     DOMAIN,
     MQTT_HANDLER,
     OPTIONS_KEY_CAMERAS,
+    # MAC address management constants
+    CONF_USE_EZVIZ_API_MAC,
+    DEFAULT_USE_EZVIZ_API_MAC,
 )
 from .coordinator import EzvizDataUpdateCoordinator
 from .mqtt import EzvizMqttHandler
@@ -119,12 +122,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if updates:
         hass.config_entries.async_update_entry(entry, data={**entry.data, **updates})
 
+    use_ezvizapi_mac = entry.data.get(CONF_USE_EZVIZ_API_MAC, DEFAULT_USE_EZVIZ_API_MAC)
+    _LOGGER.warning("init use_ezvizapi_mac = %s",use_ezvizapi_mac)
     # Coordinator
     coordinator = EzvizDataUpdateCoordinator(
         hass,
         api=client,
         api_timeout=timeout,
+        use_ezvizapi_mac=use_ezvizapi_mac,
     )
+    #coordinator.use_ezvizapi_mac = use_ezvizapi_mac
     await coordinator.async_config_entry_first_refresh()
 
     # MQTT handler

--- a/custom_components/ezviz_cloud/config_flow.py
+++ b/custom_components/ezviz_cloud/config_flow.py
@@ -62,6 +62,9 @@ from .const import (
     REGION_EU,
     REGION_RU,
     REGION_URLS,
+    # Add mac address retrieval options
+    CONF_USE_EZVIZ_API_MAC,
+    DEFAULT_USE_EZVIZ_API_MAC,
 )
 from .coordinator import EzvizDataUpdateCoordinator
 
@@ -152,8 +155,6 @@ def _infer_supports_rtsp_from_category(cam_info: dict) -> bool:
 # -----------------------------------------------------------------------------
 # Config Flow (cloud account)
 # -----------------------------------------------------------------------------
-
-
 class EzvizConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle the cloud account config flow for EZVIZ."""
 
@@ -185,6 +186,11 @@ class EzvizConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Create a single cloud account entry."""
         errors: dict[str, str] = {}
+
+        USE_EZVIZ_API_MAC_LABEL = (
+            "Use MAC address returned by official Ezviz cloud "
+            "(uncheck if your device is not detected correctly)"
+        )
 
         if user_input is not None:
             await self.async_set_unique_id(user_input[CONF_USERNAME])
@@ -241,6 +247,8 @@ class EzvizConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             CONF_USER_ID: token[
                                 "username"
                             ],  # ezviz internal user id (MQTT)
+                            # MAC address management
+                            CONF_USE_EZVIZ_API_MAC: user_input.get(USE_EZVIZ_API_MAC_LABEL, DEFAULT_USE_EZVIZ_API_MAC)
                         },
                         options={
                             CONF_TIMEOUT: timeout,
@@ -258,6 +266,8 @@ class EzvizConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
                 vol.Optional(CONF_URL): str,  # required only when region == custom
                 vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): int,
+                # MAC address management
+                vol.Required(USE_EZVIZ_API_MAC_LABEL, default=DEFAULT_USE_EZVIZ_API_MAC): bool,
             }
         )
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)

--- a/custom_components/ezviz_cloud/const.py
+++ b/custom_components/ezviz_cloud/const.py
@@ -72,3 +72,9 @@ SERVICE_WAKE_DEVICE: Final = "wake_device"
 DATA_COORDINATOR: Final = "coordinator"
 MQTT_HANDLER: Final = "mqtt_handler"
 OPTIONS_KEY_CAMERAS: Final = "cameras"
+
+# ---------------------------
+# Manage options to overload mac address when EZVIZ api returns null or duplicated MAC values
+# ---------------------------
+CONF_USE_EZVIZ_API_MAC = "use_ezvizapi_mac"
+DEFAULT_USE_EZVIZ_API_MAC = True

--- a/custom_components/ezviz_cloud/manifest.json
+++ b/custom_components/ezviz_cloud/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/RenierM26/ha-ezviz/issues",
   "loggers": ["paho_mqtt", "pyezvizapi"],
   "requirements": ["pyezvizapi==1.0.3.6"],
-  "version": "0.2.0.16"
+  "version": "0.2.0.17"
 }


### PR DESCRIPTION
Adding mecanism to generate fake MAC address for devices with no MAC returned by EZVIZ official api

W2H base station comes with 3 BC1 cameras. Each base station creates its own private Wi-Fi network on which BC1 cameras attach.
Unfortunatelly, EZVIZ official API doesn't communicate MAC address for those cameras
On top of that, each W2H base station comes with the same MAC address (which doesn't correspond to the value printed onto device tag...)
==> This generates errors in Home Assistant, and cameras are not discovered

Here is the output from pyezvizapi:
```
PS C:\Users\sss\esp\pyezviapi-w2h\pyEzvizApi\pyezvizapi> pyezvizapi.exe -u xxx -p xxx devices status
                               name  status device_category device_sub_category  sleep  privacy  audio  ir_led state_led       local_ip local_rtsp_port  battery_level  alarm_schedules_enabled  alarm_notify  Motion_Trigger        **mac_address**
G95606990            Base Extérieur       1        IGateWay                 W2H   None    False  False   False      None  192.168.1.112             554            NaN                     True          True           False  **65:63:3A:39:37:3A**
G95608196            Base Intérieur       1        IGateWay                 W2H   None    False  False   False      None  192.168.1.106             554            NaN                     True          True           False  **65:63:3A:39:37:3A**
G95606990-G95614861       Portillon       1   BatteryCamera                 BC1  False    False   True    True     False  192.168.1.112             554           59.0                    False         False           False               **None**
G95606990-G95614940    Terrasse Sud       1   BatteryCamera                 BC1  False    False   True    True     False  192.168.1.112             554           58.0                    False         False           False               **None**
G95606990-G95615117   Garage du bas       1   BatteryCamera                 BC1  False    False   True    True     False  192.168.1.112             554           82.0                    False         False           False               **None**
G95608196-G97450530         Cuisine       1   BatteryCamera                 BC1  False    False   True    True     False  192.168.1.106             554           44.0                    False         False           False               **None**
G95608196-G97451192  Salle à manger       1   BatteryCamera                 BC1  False    False   True    True     False  192.168.1.106             554           69.0                    False         False           False               **None**
G95608196-G97451221     Hall Entrée       1   BatteryCamera                 BC1  False    False   True    True     False  192.168.1.106             554           84.0                    False         False           False               **None**
```


This patch adds a new checkbox in config_flow. Keep it checked to get MAC addresses from EZVIZ cloud.
Uncheck the box to generate fake mac address values for each device